### PR TITLE
Fix broken display on large numbers

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -43,6 +43,11 @@ body {
     align-items: center;
     justify-content: end;
     padding-right: 5px;
+    overflow: auto;
+}
+
+#display-content {
+    overflow-x: auto;
 }
 
 #clear-button {

--- a/html/home.html
+++ b/html/home.html
@@ -15,7 +15,7 @@
                 <div class="clear-button-container">
                     <button id="clear-button" onclick="buttonInputHandle(this)">CE</button>
                 </div>
-                <div class="display">
+                <div class="display" >
                     <p id="display-content"></p>
                 </div>
             </div>


### PR DESCRIPTION
### **Motivo**
Ao inserir um número muito grande, o display aumentava muito de tamanho e o layout se quebrava.

### **O que foi feito**

1. Adição da propriedade overflow na classe display-container e overflow-x na classe display-content.

### **Como testar**
Inserir um número maior que o display e ver se o scroll aparece.